### PR TITLE
Convolution refactor 

### DIFF
--- a/notebooks/two_conv_layers.ipynb
+++ b/notebooks/two_conv_layers.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "backward (generic function with 16 methods)"
+       "backward (generic function with 14 methods)"
       ]
      },
      "metadata": {},
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -70,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -91,15 +91,16 @@
     "\n",
     "# variables that will be modified\n",
     "b = Variable(rand(Float64, NUM_OF_CLASSES), name=\"dense_layer_bias\")\n",
-    "w = Variable(rand(Float64, (NUM_OF_CLASSES, 13 * 13)) ./ 10, name=\"dense_layer_weights\")\n",
+    "w = Variable(rand(Float64, (NUM_OF_CLASSES, 12 * 12)) ./ 10, name=\"dense_layer_weights\")\n",
     "w_conv = Variable(rand(Float64, 1, 9), name=\"convolution_weights\")\n",
+    "w_conv2 = Variable(rand(Float64, 1, 9), name=\"convolution2_weights\")\n",
     "train_dataset = MNIST(:train)\n",
     "N = size(train_dataset.features)[3]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -107,7 +108,7 @@
       "text/plain": [
        "19-element Vector{Any}:\n",
        " var dense_layer_weights\n",
-       " ┣━ ^ 10×169 Matrix{Float64}\n",
+       " ┣━ ^ 10×144 Matrix{Float64}\n",
        " ┗━ ∇ Nothing\n",
        " var img\n",
        " ┣━ ^ 28×28 Matrix{Float64}\n",
@@ -118,8 +119,10 @@
        " const 3\n",
        " const 1\n",
        " op.?(typeof(conv))\n",
-       " const 0\n",
-       " op.?(typeof(max))\n",
+       " var convolution2_weights\n",
+       " ┣━ ^ 1×9 Matrix{Float64}\n",
+       " ┗━ ∇ Nothing\n",
+       " op.?(typeof(conv))\n",
        " const 2\n",
        " op.?(typeof(maxpool))\n",
        " op.?(typeof(flatten))\n",
@@ -146,8 +149,9 @@
     "img = Variable(Float64.(train_dataset[1].features), name=\"img\")\n",
     "actual_class = Variable(train_dataset[1].targets + 1, name=\"actual_class\")\n",
     "# Layers\n",
-    "conv_layer = relu(conv(img, w_conv, Constant(3), Constant(3),Constant(1)))\n",
-    "max_pool_layer = maxpool(conv_layer, Constant(2))\n",
+    "conv_layer = conv(img, w_conv, Constant(3), Constant(3),Constant(1))\n",
+    "conv_layer2 = conv(conv_layer, w_conv2, Constant(3), Constant(3),Constant(1))\n",
+    "max_pool_layer = maxpool(conv_layer2, Constant(2))\n",
     "flatten_layer = flatten(max_pool_layer)\n",
     "fc_layer = dense(w, b, flatten_layer, softmax)\n",
     "loss = crossentropy(fc_layer, actual_class)\n",
@@ -164,22 +168,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Avarage loss during epoch #1 run : 0.498936 \n",
-      "Avarage loss during epoch #2 run : 0.465217 \n"
+      "Avarage loss during epoch #1 run : 0.567660 \n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Avarage loss during epoch #3 run : 0.356239 \n"
+      "Avarage loss during epoch #2 run : 0.497036 \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Avarage loss during epoch #3 run : 0.466534 \n"
      ]
     }
    ],
@@ -194,6 +204,7 @@
     "        backward!(net)\n",
     "        update_var!(b, LEARNING_RATE)\n",
     "        update_var!(w, LEARNING_RATE)\n",
+    "        update_var!(w_conv2, LEARNING_RATE)\n",
     "        update_var!(w_conv, LEARNING_RATE)\n",
     "    end\n",
     "    @printf(\"Avarage loss during epoch #%d run : %f \\n\", j, mean(losses))\n",
@@ -210,15 +221,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Testing network...\n",
-      "Network accuracy:  0.901000 \n"
+      "Testing network...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Network accuracy:  0.873600 \n"
      ]
     }
    ],

--- a/scripts/cnn.jl
+++ b/scripts/cnn.jl
@@ -19,7 +19,7 @@ function dense(w, x)
     return w * x
 end
 
-function crossentropy(y, actual_class)
+function sparse_categorical_crossentropy(y, actual_class)
     select(.-log.(y), actual_class)
 end
 
@@ -38,7 +38,7 @@ EPOCHS = 5
 # variables that will be modified
 b = Variable(rand(Float64, NUM_OF_CLASSES), name="dense_layer_bias")
 w = Variable(rand(Float64, (NUM_OF_CLASSES, 13 * 13)) ./ 10, name="dense_layer_weights")
-w_conv = Variable(reshape(1:9, 1, 9), name="convolution_weights")
+w_conv = Variable(rand(Float32, 1, 9), name="convolution_weights")
 
 train_dataset = MNIST(:train)
 N = size(train_dataset.features)[3]
@@ -47,11 +47,11 @@ N = size(train_dataset.features)[3]
 img = Variable(train_dataset[1].features, name="img")
 actual_class = Variable(train_dataset[1].targets + 1, name="actual_class")
 # Layers
-conv_layer = conv(img, w_conv, Constant(3), Constant(3))
+conv_layer = conv(img, w_conv, Constant(3), Constant(3), Constant(1))
 max_pool_layer = maxpool(conv_layer, Constant(2))
 flatten_layer = flatten(max_pool_layer)
 fc_layer = dense(w, b, flatten_layer, softmax)
-loss = crossentropy(fc_layer, actual_class)
+loss = sparse_categorical_crossentropy(fc_layer, actual_class)
 net = topological_sort(loss)
 
 # Training

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -56,8 +56,8 @@ Base.Broadcast.broadcasted(max, x::GraphNode, y::GraphNode) = MatrixOperator(max
 forward(::MatrixOperator{typeof(max)}, x, y) = return max.(x, y)
 backward(::MatrixOperator{typeof(max)}, x, y, g) =
     let
-        Jx = diagm(isless.(y, x))
-        Jy = diagm(isless.(x, y))
+        Jx = isless.(y, x)
+        Jy = isless.(x, y)
         tuple(Jx' * g, Jy' * g)
     end
 
@@ -94,7 +94,7 @@ backward(::MatrixOperator{typeof(flatten)}, x, g) =
     end
 
 
-function im2col(x::Matrix{Float32}, m::Int, n::Int, stride::Int)
+function im2col(x::Matrix{Float64}, m::Int, n::Int, stride::Int)
     M, N = size(x)
     mc = (M - m) ÷ stride + 1
     nc = (N - n) ÷ stride + 1
@@ -112,14 +112,14 @@ end
 
 
 conv(x::GraphNode, w::GraphNode, m::Constant, n::Constant, stride::Constant) = ConvOperator(conv, x, w, m, n, stride)
-forward(conv_layer::ConvOperator{typeof(conv)}, x::Matrix{Float32}, w::Matrix{Float64}, m::Int, n::Int, stride::Int) =
+forward(conv_layer::ConvOperator{typeof(conv)}, x::Matrix{Float64}, w::Matrix{Float64}, m::Int, n::Int, stride::Int) =
     let
         M, N = size(x)
         b = im2col(x, m, n, stride)
         conv_layer.im2col = b
         reshape(w * b, (M - m) ÷ stride + 1, (N - n) ÷ stride + 1)
     end
-backward(conv_layer::ConvOperator{typeof(conv)}, x::Matrix{Float32}, w::Matrix{Float32}, m::Int, n::Int, stride::Int, g) =
+backward(conv_layer::ConvOperator{typeof(conv)}, x::Matrix{Float64}, w::Matrix{Float64}, m::Int, n::Int, stride::Int, g) =
     let
         M, N = size(x)
         mc = (M - m) ÷ stride + 1

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -112,14 +112,14 @@ end
 
 
 conv(x::GraphNode, w::GraphNode, m::Constant, n::Constant, stride::Constant) = ConvOperator(conv, x, w, m, n, stride)
-forward(conv_layer::ConvOperator{typeof(conv)}, x::Matrix{Float32}, w::Matrix{Float32}, m::Int, n::Int, stride::Int) =
+forward(conv_layer::ConvOperator{typeof(conv)}, x::Matrix{Float32}, w::Matrix{Float64}, m::Int, n::Int, stride::Int) =
     let
         M, N = size(x)
         b = im2col(x, m, n, stride)
         conv_layer.im2col = b
         reshape(w * b, (M - m) ÷ stride + 1, (N - n) ÷ stride + 1)
     end
-backward(conv_layer::ConvOperator{typeof(conv)}, x::Matrix{Float32}, w::Matrix{Float64}, m::Int, n::Int, stride::Int, g) =
+backward(conv_layer::ConvOperator{typeof(conv)}, x::Matrix{Float32}, w::Matrix{Float32}, m::Int, n::Int, stride::Int, g) =
     let
         M, N = size(x)
         mc = (M - m) ÷ stride + 1

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -119,7 +119,7 @@ forward(conv_layer::ConvOperator{typeof(conv)}, x::Matrix{Float64}, w::Matrix{Fl
         conv_layer.im2col = b
         reshape(w * b, (M - m) ÷ stride + 1, (N - n) ÷ stride + 1)
     end
-backward(conv_layer::ConvOperator{typeof(conv)}, x::Matrix{Float64}, w::Matrix{Float64}, m::Int, n::Int, stride::Int, g) =
+backward(conv_layer::ConvOperator{typeof(conv)}, x::Matrix{Float64}, w::Matrix{Float64}, m::Int, n::Int, stride::Int, g::Matrix{Float64}) =
     let
         M, N = size(x)
         mc = (M - m) ÷ stride + 1


### PR DESCRIPTION
- conv operator refactor in terms of performance (static types added + reduction of memory allocations
- stride added to conv operator
- images from MNIST are now converted to float64 from float32 
- relu activation added to example entwork in scripts/cnn.jl and notebooks/prototyping.ipynb
- working example of network with two conv layers notebooks/two_conv_layers.ipynb

#2 