### PR TITLE
Static types in operators

### DIFF
--- a/scripts/cnn.jl
+++ b/scripts/cnn.jl
@@ -23,8 +23,8 @@ function sparse_categorical_crossentropy(y, actual_class)
     select(.-log.(y), actual_class)
 end
 
-function relu(x)
-    max.(x, Constant(0))
+function relu(x::GraphNode)
+    max.(x, Constant(0.0))
 end
 
 -(x::Vector, y::Matrix) = vec(x .- y)

--- a/scripts/cnn.jl
+++ b/scripts/cnn.jl
@@ -9,17 +9,17 @@ include(srcdir("operators.jl"))
 
 
 
-function dense(w, b, x, activation)
+function dense(w::Variable, b::Variable, x::Operator, activation::Function)
     return activation(w * x .+ b)
 end
-function dense(w, x, activation)
+function dense(w::Variable, x::Operator, activation::Function)
     return activation(w * x)
 end
-function dense(w, x)
+function dense(w::Variable, x::Operator)
     return w * x
 end
 
-function sparse_categorical_crossentropy(y, actual_class)
+function sparse_categorical_crossentropy(y::Operator, actual_class::Variable)
     select(.-log.(y), actual_class)
 end
 
@@ -29,7 +29,7 @@ end
 
 -(x::Vector, y::Matrix) = vec(x .- y)
 
-function update_vars!(vars::Vector{Variable}, alpha)
+function update_vars!(vars::Vector{Variable}, alpha::Float64)
     for i in eachindex(vars)
         vars[i].output = vars[i].output - (vars[i].gradient * alpha)
     end

--- a/src/graph_nodes.jl
+++ b/src/graph_nodes.jl
@@ -8,28 +8,28 @@ struct Constant{T} <: GraphNode
 end
 
 mutable struct Variable <: GraphNode
-    output::Any
-    gradient::Any
+    output::Union{Nothing, Matrix{Float64}, Vector{Float64}, Int}   #TODO: sprawdzić czy nie można ograniczyć
+    gradient::Union{Nothing, Matrix{Float64}}
     name::String
     Variable(output; name="?") = new(output, nothing, name)
 end
 
 
 mutable struct MatrixOperator{F} <: Operator
-    inputs::Any
-    output::Any
-    gradient::Any
+    inputs::Union{Tuple{GraphNode}, Tuple{GraphNode, GraphNode}}    #TODO: sprawdzić czy nie można ograniczyć
+    output::Union{Nothing, Matrix{Float64}, Vector{Float64}, Float64}
+    gradient::Union{Nothing, Float64, Matrix{Float64}, Adjoint{Float64, Matrix{Float64}}, Adjoint{Float64, Vector{Float64}}}
     name::String
     MatrixOperator(fun, inputs...; name="?") = new{typeof(fun)}(inputs, nothing, nothing, name)
 end
 
 
 mutable struct ConvOperator{F} <: Operator
-    inputs::Any
-    output::Any
-    gradient::Any
+    inputs::Tuple{GraphNode, GraphNode, Constant{Int64}, Constant{Int64}, Constant{Int64}}
+    output::Union{Nothing, Matrix{Float64}}
+    gradient::Union{Nothing, Matrix{Float64}}
     name::String
-    im2col::Any
+    im2col::Union{Nothing, Matrix{Float64}}
     ConvOperator(fun, inputs...; name="?") = new{typeof(fun)}(inputs, nothing, nothing, name, nothing)
 end
 

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -151,7 +151,7 @@ forward(::MatrixOperator{typeof(maxpool)}, x::Matrix{Float64}, n::Int) =
         for i = 1:n:M
             for j = 1:n:N
                 @views x_view = x[i:(i+n-1), j:(j+n-1)]
-                out[(i+1)÷n, (j+1)÷n] = maximum(x_view)
+                out[1+i÷n, 1+j÷n] = maximum(x_view)
             end
         end
         out

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -5,8 +5,8 @@ using LinearAlgebra
 include(srcdir("graph_nodes.jl"))
 
 *(A::GraphNode, x::GraphNode) = MatrixOperator(mul!, A, x)
-forward(::MatrixOperator{typeof(mul!)}, A, x) = return A * x
-backward(::MatrixOperator{typeof(mul!)}, A, x, g) = tuple(g * x', A' * g)
+forward(::MatrixOperator{typeof(mul!)}, A::Matrix{Float64}, x::Vector{Float64}) = return A * x
+backward(::MatrixOperator{typeof(mul!)}, A::Matrix{Float64}, x::Vector{Float64}, g::Matrix{Float64}) = tuple(g * x', A' * g)
 
 Base.Broadcast.broadcasted(*, x::GraphNode, y::GraphNode) = MatrixOperator(*, x, y)
 forward(::MatrixOperator{typeof(*)}, x, y) = return x .* y
@@ -19,17 +19,17 @@ backward(node::MatrixOperator{typeof(*)}, x, y, g) =
     end
 
 
-Base.Broadcast.broadcasted(-, x::GraphNode, y::GraphNode) = MatrixOperator(-, x, y)
-forward(::MatrixOperator{typeof(-)}, x, y) = return x .- y
-backward(::MatrixOperator{typeof(-)}, x, y, g) = tuple(g, -g)
+#Base.Broadcast.broadcasted(-, x::GraphNode, y::GraphNode) = MatrixOperator(-, x, y)
+#forward(::MatrixOperator{typeof(-)}, x, y) = return x .- y
+#backward(::MatrixOperator{typeof(-)}, x, y, g) = tuple(g, -g)
 
 Base.Broadcast.broadcasted(-, x::GraphNode) = MatrixOperator(-, x)
-forward(::MatrixOperator{typeof(-)}, x,) = return .-x
-backward(::MatrixOperator{typeof(-)}, x, g) = tuple(-g)
+forward(::MatrixOperator{typeof(-)}, x::Vector{Float64}) = return .-x
+backward(::MatrixOperator{typeof(-)}, x::Vector{Float64}, g::AbstractArray{Float64}) = tuple(-g)
 
 Base.Broadcast.broadcasted(+, x::GraphNode, y::GraphNode) = MatrixOperator(+, x, y)
-forward(::MatrixOperator{typeof(+)}, x, y) = return x .+ y
-backward(::MatrixOperator{typeof(+)}, x, y, g) = tuple(g, g)
+forward(::MatrixOperator{typeof(+)}, x::Vector{Float64}, y::Vector{Float64}) = return x .+ y
+backward(::MatrixOperator{typeof(+)}, x::Vector{Float64}, y::Vector{Float64}, g::Matrix{Float64}) = tuple(g, g)
 
 
 sum(x::GraphNode) = MatrixOperator(sum, x)
@@ -53,8 +53,8 @@ backward(node::MatrixOperator{typeof(/)}, x, y::Real, g) =
 
 
 Base.Broadcast.broadcasted(max, x::GraphNode, y::GraphNode) = MatrixOperator(max, x, y)
-forward(::MatrixOperator{typeof(max)}, x, y) = return max.(x, y)
-backward(::MatrixOperator{typeof(max)}, x, y, g) =
+forward(::MatrixOperator{typeof(max)}, x::Matrix{Float64}, y::Float64) = return max.(x, y)
+backward(::MatrixOperator{typeof(max)}, x::Matrix{Float64}, y::Float64, g::Matrix{Float64}) =
     let
         Jx = isless.(y, x)
         Jy = isless.(x, y)
@@ -63,8 +63,8 @@ backward(::MatrixOperator{typeof(max)}, x, y, g) =
 
 
 Base.Broadcast.broadcasted(log, x::GraphNode) = MatrixOperator(log, x)
-forward(::MatrixOperator{typeof(log)}, x) = return log.(x)
-backward(::MatrixOperator{typeof(log)}, x, g) = tuple(((1 ./ x)' .* g)')
+forward(::MatrixOperator{typeof(log)}, x::Vector{Float64}) = return log.(x)
+backward(::MatrixOperator{typeof(log)}, x::Vector{Float64}, g::AbstractMatrix{Float64}) = tuple(((1 ./ x)' .* g)')
 
 
 select(x::GraphNode, index) = MatrixOperator(select, x, index)
@@ -77,8 +77,8 @@ backward(::MatrixOperator{typeof(select)}, x, index, g) =
     end
 
 softmax(x::GraphNode) = MatrixOperator(softmax, x)
-forward(::MatrixOperator{typeof(softmax)}, x) = return exp.(x) ./ sum(exp.(x))
-backward(node::MatrixOperator{typeof(softmax)}, x, g) =
+forward(::MatrixOperator{typeof(softmax)}, x::Vector{Float64}) = return exp.(x) ./ sum(exp.(x))
+backward(node::MatrixOperator{typeof(softmax)}, x::Vector{Float64}, g::AbstractMatrix{Float64}) =
     let
         y = node.output
         J = diagm(y) .- y * y'
@@ -86,8 +86,8 @@ backward(node::MatrixOperator{typeof(softmax)}, x, g) =
     end
 
 flatten(x::GraphNode) = MatrixOperator(flatten, x)
-forward(::MatrixOperator{typeof(flatten)}, x) = return vec(x)
-backward(::MatrixOperator{typeof(flatten)}, x, g) =
+forward(::MatrixOperator{typeof(flatten)}, x::Matrix{Float64}) = return vec(x)
+backward(::MatrixOperator{typeof(flatten)}, x::Matrix{Float64}, g::Matrix{Float64}) =
     let
         M, N = size(x)
         tuple(reshape(g, M, N))
@@ -142,7 +142,7 @@ backward(conv_layer::ConvOperator{typeof(conv)}, x::Matrix{Float64}, w::Matrix{F
 
 
 maxpool(x::GraphNode, n::Constant) = MatrixOperator(maxpool, x, n)
-forward(::MatrixOperator{typeof(maxpool)}, x, n) =
+forward(::MatrixOperator{typeof(maxpool)}, x::Matrix{Float64}, n::Int) =
     let
         M, N = size(x)
         M_out = 1 + (M - n) ÷ n
@@ -150,19 +150,20 @@ forward(::MatrixOperator{typeof(maxpool)}, x, n) =
         out = zeros(M_out, N_out)
         for i = 1:n:M
             for j = 1:n:N
-                out[(i+1)÷n, (j+1)÷n] = maximum(x[i:(i+n-1), j:(j+n-1)])
+                @views x_view = x[i:(i+n-1), j:(j+n-1)]
+                out[(i+1)÷n, (j+1)÷n] = maximum(x_view)
             end
         end
         out
     end
-backward(::MatrixOperator{typeof(maxpool)}, x, n, g) =
+backward(::MatrixOperator{typeof(maxpool)}, x::Matrix{Float64}, n::Int, g::Matrix{Float64}) =
     let
         M, N = size(x)
         M_out, N_out = size(g)
         dx = zeros(M, N)
         for i = 1:M_out
             for j = 1:N_out
-                pool = x[1+(i-1)*n:i*n, 1+(j-1)*n:j*n]
+                @views pool = x[1+(i-1)*n:i*n, 1+(j-1)*n:j*n]
                 mask = (pool .== maximum(pool))
                 dx[1+(i-1)*n:i*n, 1+(j-1)*n:j*n] = mask * g[i, j]
             end

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -64,8 +64,8 @@ backward(::MatrixOperator{typeof(log)}, x::Vector{Float64}, g::AbstractMatrix{Fl
 
 
 select(x::GraphNode, index) = MatrixOperator(select, x, index)
-forward(::MatrixOperator{typeof(select)}, x, index) = return x[index]
-backward(::MatrixOperator{typeof(select)}, x, index, g) =
+forward(::MatrixOperator{typeof(select)}, x::Vector{Float64}, index::Int) = return x[index]
+backward(::MatrixOperator{typeof(select)}, x::Vector{Float64}, index::Int, g::Float64) =
     let
         result = zeros(size(x))
         result[index] = g

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -8,21 +8,17 @@ include(srcdir("graph_nodes.jl"))
 forward(::MatrixOperator{typeof(mul!)}, A::Matrix{Float64}, x::Vector{Float64}) = return A * x
 backward(::MatrixOperator{typeof(mul!)}, A::Matrix{Float64}, x::Vector{Float64}, g::Matrix{Float64}) = tuple(g * x', A' * g)
 
-#Base.Broadcast.broadcasted(*, x::GraphNode, y::GraphNode) = MatrixOperator(*, x, y)
-#forward(::MatrixOperator{typeof(*)}, x, y) = return x .* y
-#backward(node::MatrixOperator{typeof(*)}, x, y, g) =
-#    let
-#        𝟏 = ones(length(node.output))
-#        Jx = diagm(y .* 𝟏)
-#        Jy = diagm(x .* 𝟏)
-#        tuple(Jx' * g, Jy' * g)
-#    end
+Base.Broadcast.broadcasted(*, x::GraphNode, y::GraphNode) = MatrixOperator(*, x, y)
+forward(::MatrixOperator{typeof(*)}, x::Vector{Float64}, y::Vector{Float64}) = return x .* y
+backward(node::MatrixOperator{typeof(*)}, x::Vector{Float64}, y::Vector{Float64}, g::Vector{Float64}) =
+    let
+        𝟏 = ones(length(node.output))
+        Jx = diagm(y .* 𝟏)
+        Jy = diagm(x .* 𝟏)
+        tuple(Jx' * g, Jy' * g)
+    end
 
-
-#Base.Broadcast.broadcasted(-, x::GraphNode, y::GraphNode) = MatrixOperator(-, x, y)
-#forward(::MatrixOperator{typeof(-)}, x, y) = return x .- y
-#backward(::MatrixOperator{typeof(-)}, x, y, g) = tuple(g, -g)
-
+    
 Base.Broadcast.broadcasted(-, x::GraphNode) = MatrixOperator(-, x)
 forward(::MatrixOperator{typeof(-)}, x::Vector{Float64}) = return .-x
 backward(::MatrixOperator{typeof(-)}, x::Vector{Float64}, g::AbstractArray{Float64}) = tuple(-g)

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -8,15 +8,15 @@ include(srcdir("graph_nodes.jl"))
 forward(::MatrixOperator{typeof(mul!)}, A::Matrix{Float64}, x::Vector{Float64}) = return A * x
 backward(::MatrixOperator{typeof(mul!)}, A::Matrix{Float64}, x::Vector{Float64}, g::Matrix{Float64}) = tuple(g * x', A' * g)
 
-Base.Broadcast.broadcasted(*, x::GraphNode, y::GraphNode) = MatrixOperator(*, x, y)
-forward(::MatrixOperator{typeof(*)}, x, y) = return x .* y
-backward(node::MatrixOperator{typeof(*)}, x, y, g) =
-    let
-        𝟏 = ones(length(node.output))
-        Jx = diagm(y .* 𝟏)
-        Jy = diagm(x .* 𝟏)
-        tuple(Jx' * g, Jy' * g)
-    end
+#Base.Broadcast.broadcasted(*, x::GraphNode, y::GraphNode) = MatrixOperator(*, x, y)
+#forward(::MatrixOperator{typeof(*)}, x, y) = return x .* y
+#backward(node::MatrixOperator{typeof(*)}, x, y, g) =
+#    let
+#        𝟏 = ones(length(node.output))
+#        Jx = diagm(y .* 𝟏)
+#        Jy = diagm(x .* 𝟏)
+#        tuple(Jx' * g, Jy' * g)
+#    end
 
 
 #Base.Broadcast.broadcasted(-, x::GraphNode, y::GraphNode) = MatrixOperator(-, x, y)
@@ -98,7 +98,7 @@ function im2col(x::Matrix{Float64}, m::Int, n::Int, stride::Int)
     M, N = size(x)
     mc = (M - m) ÷ stride + 1
     nc = (N - n) ÷ stride + 1
-    B = Array{Float32}(undef, m * n, mc * nc)
+    B = Array{Float64}(undef, m * n, mc * nc)
     for j = 1:nc
         for i = 1:mc
             @views block = x[((i-1)*stride+1):((i-1)*stride+1+m-1), (j-1)*stride+1:(j-1)*stride+1+n-1]


### PR DESCRIPTION
Uzupełniłem na ten moment typy statyczne w operatorach sieci. Pojawia się coś takiego jak AbstractMatrix i z tego co czytałem wynika to z transpozycji wektorów/macierzy (tworzy się adjoint). Jest to pewnego rodzaju wrapper, nie wiem na ile jest gorszy od zwykłego typu.

Zacząłem się przyglądać jak to poprawić i trzeba byłoby przeanalizować operacje i postarać się wyeliminować niepotrzebne transpozycje.

Pojawia się pierwszy raz w operatorze _select_ przy transpozycji (adjoint) wektora wynikowego.