### PR TITLE
Maxpool refactor

### DIFF
--- a/src/graph_nodes.jl
+++ b/src/graph_nodes.jl
@@ -8,7 +8,7 @@ struct Constant{T} <: GraphNode
 end
 
 mutable struct Variable <: GraphNode
-    output::Union{Nothing, Matrix{Float64}, Vector{Float64}, Int}   #TODO: sprawdzić czy nie można ograniczyć
+    output::Union{Nothing, Matrix{Float64}, Vector{Float64}, Int}
     gradient::Union{Nothing, Matrix{Float64}}
     name::String
     Variable(output; name="?") = new(output, nothing, name)
@@ -16,7 +16,7 @@ end
 
 
 mutable struct MatrixOperator{F} <: Operator
-    inputs::Union{Tuple{GraphNode}, Tuple{GraphNode, GraphNode}}    #TODO: sprawdzić czy nie można ograniczyć
+    inputs::Union{Tuple{GraphNode}, Tuple{GraphNode, GraphNode}}
     output::Union{Nothing, Matrix{Float64}, Vector{Float64}, Float64}
     gradient::Union{Nothing, Float64, Matrix{Float64}, Adjoint{Float64, Matrix{Float64}}, Adjoint{Float64, Vector{Float64}}}
     name::String

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -147,9 +147,11 @@ forward(::MatrixOperator{typeof(maxpool)}, x, n) =
         M, N = size(x)
         M_out = 1 + (M - n) ÷ n
         N_out = 1 + (N - n) ÷ n
+        M_reminder = mod(M - n, n)
+        N_reminder = mod(M - n, n)
         out = zeros(M_out, N_out)
-        for i = 1:n:M
-            for j = 1:n:N
+        for i = 1:n:M-M_reminder
+            for j = 1:n:N-N_reminder
                 out[1+i÷n, 1+j÷n] = maximum(x[i:(i+n-1), j:(j+n-1)])
             end
         end


### PR DESCRIPTION
Bounding indexing, so if input and MaxPool parameters are not matched, result still will be computed by ignoring outer rows and columns.